### PR TITLE
Fix imports and enable mouse panning

### DIFF
--- a/config_dialog.py
+++ b/config_dialog.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QFormLayout,
-    QLabel, QLineEdit, QCheckBox,
+    QLineEdit, QCheckBox,
     QDialogButtonBox, QTabWidget,
     QWidget, QDoubleSpinBox, QSpinBox
 )

--- a/exporters/kml_exporter.py
+++ b/exporters/kml_exporter.py
@@ -1,15 +1,6 @@
 # exporters/kml_exporter.py
 from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.dom import minidom
-from pyproj import Transformer, ProjError # Import ProjError for specific exception handling
-
-# Si se usaran constantes de GeometryType, se importarían aquí.
-# from core.coordinate_manager import GeometryType
-
-# exporters/kml_exporter.py
-
-from xml.etree.ElementTree import Element, SubElement, tostring
-from xml.dom import minidom
 from pyproj import Transformer
 
 class KMLExporter:

--- a/exporters/kmz_exporter.py
+++ b/exporters/kmz_exporter.py
@@ -1,5 +1,4 @@
 import zipfile
-import io # io is not strictly needed with the current _generate_kml_string, but good if we change it to use StringIO
 from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.dom import minidom
 from pyproj import Transformer

--- a/gui.py
+++ b/gui.py
@@ -1,21 +1,29 @@
 import os
-from PySide6.QtWidgets import QTextEdit
-from PySide6.QtCore import Qt, QRegularExpression, QPointF, QItemSelectionModel
 import csv
-from PySide6.QtWidgets import QFileDialog
+
+from PySide6.QtCore import (
+    Qt,
+    QRegularExpression,
+    QSize,
+    QItemSelectionModel,
+)
 from PySide6.QtGui import (
     QAction,
     QRegularExpressionValidator,
     QBrush,
-    QPainterPath,
-    QPen
+    QPen,
+    QPixmap,
+    QPainter,
+    QColor,
+    QIcon,
+    QPalette,
 )
+from PySide6.QtSvg import QSvgRenderer
 from PySide6.QtWidgets import (
     QApplication,
     QMainWindow,
     QWidget,
     QToolBar,
-    QStyle,
     QMessageBox,
     QVBoxLayout,
     QHBoxLayout,
@@ -32,24 +40,20 @@ from PySide6.QtWidgets import (
     QMenu,
     QStyledItemDelegate,
     QTableWidget,
-    QTableWidgetItem
+    QTableWidgetItem,
+    QDialog,
+    QTextEdit,
 )
 
-from PySide6.QtWidgets import QDialog, QVBoxLayout
 from config_dialog import ConfigDialog
 from help_dialog import HelpDialog
 from core.coordinate_manager import CoordinateManager, GeometryType
 from exporters.kml_exporter import KMLExporter
-from exporters.kmz_exporter import KMZExporter # Asumiendo que existe
-from exporters.shapefile_exporter import ShapefileExporter # Asumiendo que existe
+from exporters.kmz_exporter import KMZExporter  # Asumiendo que existe
+from exporters.shapefile_exporter import ShapefileExporter  # Asumiendo que existe
 from importers.csv_importer import CSVImporter
-from importers.kml_importer import KMLImporter # Importar KMLImporter
+from importers.kml_importer import KMLImporter  # Importar KMLImporter
 from core.geometry import GeometryBuilder
-from PySide6.QtGui import QIcon
-from PySide6.QtSvg import QSvgRenderer
-from PySide6.QtGui import QPixmap, QPainter, QColor, QIcon, QPalette
-from PySide6.QtCore import QSize, Qt
-from PySide6.QtGui import QPalette
 
 class UTMDelegate(QStyledItemDelegate):
     def createEditor(self, parent, option, index):
@@ -191,6 +195,10 @@ class MainWindow(QMainWindow):
         self.canvas.setScene(self.scene)
         self.canvas.setMinimumSize(400,300)
         self.canvas.setStyleSheet("background-color:white; border:1px solid #ccc; padding:8px;")
+        # Permitir desplazamiento con el cursor en lugar de barras de scroll
+        self.canvas.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.canvas.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.canvas.setDragMode(QGraphicsView.ScrollHandDrag)
 
         # ensamblar
         main_layout.addLayout(control,1)

--- a/importers/kml_importer.py
+++ b/importers/kml_importer.py
@@ -280,7 +280,7 @@ if __name__ == '__main__':
     except Exception as e:
         print(f"  Error: {e}")
 
-    print(f"\n--- Probando con zona inválida ---")
+    print("\n--- Probando con zona inválida ---")
     try:
         importer.import_file(test_kml_file, target_hemisphere='Sur', target_zone=99)
     except Exception as e:


### PR DESCRIPTION
## Summary
- clean unused duplicate imports across modules
- fix string literal in KML importer test block
- allow panning on the canvas via mouse drag and hide scrollbars

## Testing
- `pyflakes $(git ls-files '*.py')`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68565a70281483288511e99216a198bb