### PR TITLE
Fix table navigation and enable map backdrop

### DIFF
--- a/config_dialog.py
+++ b/config_dialog.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import (
     QDialog, QVBoxLayout, QFormLayout,
-    QLabel, QLineEdit, QCheckBox,
+    QLineEdit, QCheckBox,
     QDialogButtonBox, QTabWidget,
     QWidget, QDoubleSpinBox, QSpinBox
 )

--- a/exporters/kml_exporter.py
+++ b/exporters/kml_exporter.py
@@ -1,15 +1,6 @@
 # exporters/kml_exporter.py
 from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.dom import minidom
-from pyproj import Transformer, ProjError # Import ProjError for specific exception handling
-
-# Si se usaran constantes de GeometryType, se importarían aquí.
-# from core.coordinate_manager import GeometryType
-
-# exporters/kml_exporter.py
-
-from xml.etree.ElementTree import Element, SubElement, tostring
-from xml.dom import minidom
 from pyproj import Transformer
 
 class KMLExporter:

--- a/exporters/kmz_exporter.py
+++ b/exporters/kmz_exporter.py
@@ -1,5 +1,4 @@
 import zipfile
-import io # io is not strictly needed with the current _generate_kml_string, but good if we change it to use StringIO
 from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.dom import minidom
 from pyproj import Transformer

--- a/gui.py
+++ b/gui.py
@@ -1,21 +1,31 @@
 import os
-from PySide6.QtWidgets import QTextEdit
-from PySide6.QtCore import Qt, QRegularExpression, QPointF, QItemSelectionModel
 import csv
-from PySide6.QtWidgets import QFileDialog
+from urllib.request import urlopen
+
+from PySide6.QtCore import (
+    Qt,
+    QRegularExpression,
+    QSize,
+    QItemSelectionModel,
+    QEvent,
+)
 from PySide6.QtGui import (
     QAction,
     QRegularExpressionValidator,
     QBrush,
-    QPainterPath,
-    QPen
+    QPen,
+    QPixmap,
+    QPainter,
+    QColor,
+    QIcon,
+    QPalette,
 )
+from PySide6.QtSvg import QSvgRenderer
 from PySide6.QtWidgets import (
     QApplication,
     QMainWindow,
     QWidget,
     QToolBar,
-    QStyle,
     QMessageBox,
     QVBoxLayout,
     QHBoxLayout,
@@ -32,24 +42,21 @@ from PySide6.QtWidgets import (
     QMenu,
     QStyledItemDelegate,
     QTableWidget,
-    QTableWidgetItem
+    QTableWidgetItem,
+    QDialog,
+    QTextEdit,
 )
 
-from PySide6.QtWidgets import QDialog, QVBoxLayout
 from config_dialog import ConfigDialog
 from help_dialog import HelpDialog
 from core.coordinate_manager import CoordinateManager, GeometryType
 from exporters.kml_exporter import KMLExporter
-from exporters.kmz_exporter import KMZExporter # Asumiendo que existe
-from exporters.shapefile_exporter import ShapefileExporter # Asumiendo que existe
+from exporters.kmz_exporter import KMZExporter  # Asumiendo que existe
+from exporters.shapefile_exporter import ShapefileExporter  # Asumiendo que existe
 from importers.csv_importer import CSVImporter
-from importers.kml_importer import KMLImporter # Importar KMLImporter
+from importers.kml_importer import KMLImporter  # Importar KMLImporter
 from core.geometry import GeometryBuilder
-from PySide6.QtGui import QIcon
-from PySide6.QtSvg import QSvgRenderer
-from PySide6.QtGui import QPixmap, QPainter, QColor, QIcon, QPalette
-from PySide6.QtCore import QSize, Qt
-from PySide6.QtGui import QPalette
+from pyproj import Transformer
 
 class UTMDelegate(QStyledItemDelegate):
     def createEditor(self, parent, option, index):
@@ -57,7 +64,42 @@ class UTMDelegate(QStyledItemDelegate):
         # 6-7 dígitos + decimales opcionales
         rx = QRegularExpression(r'^\d{6,7}(\.\d+)?$')
         editor.setValidator(QRegularExpressionValidator(rx, editor))
+        editor.installEventFilter(self)
+        editor.setProperty("row", index.row())
+        editor.setProperty("column", index.column())
         return editor
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.KeyPress and event.key() == Qt.Key_Tab:
+            table = obj.parent()
+            while table and not isinstance(table, QTableWidget):
+                table = table.parent()
+            if not table:
+                return False
+            row = obj.property("row")
+            col = obj.property("column")
+            if col == 1:
+                table.setCurrentCell(row, 2)
+                item = table.item(row, 2)
+                if item is None:
+                    item = QTableWidgetItem("")
+                    table.setItem(row, 2, item)
+                table.editItem(item)
+            elif col == 2:
+                next_row = row + 1
+                if next_row >= table.rowCount():
+                    table.insertRow(next_row)
+                    id_it = QTableWidgetItem(str(next_row + 1))
+                    id_it.setFlags(Qt.ItemIsEnabled)
+                    table.setItem(next_row, 0, id_it)
+                table.setCurrentCell(next_row, 1)
+                item = table.item(next_row, 1)
+                if item is None:
+                    item = QTableWidgetItem("")
+                    table.setItem(next_row, 1, item)
+                table.editItem(item)
+            return True
+        return super().eventFilter(obj, event)
 
     def setModelData(self, editor, model, index):
         text = editor.text()
@@ -71,9 +113,29 @@ class CoordTable(QTableWidget):
     def keyPressEvent(self, event):
         # Tab: al salir de Y, saltar a X de la siguiente fila
         if event.key() == Qt.Key_Tab and self.currentColumn() == 2:
-            self.setCurrentCell(self.currentRow() + 1, 1)
+            next_row = self.currentRow() + 1
+            if next_row < self.rowCount():
+                self.setCurrentCell(next_row, 1)
+                # Comenzar edición inmediatamente
+                item = self.item(next_row, 1)
+                if item is None:
+                    item = QTableWidgetItem("")
+                    self.setItem(next_row, 1, item)
+                self.editItem(item)
             return
         super().keyPressEvent(event)
+
+class CanvasView(QGraphicsView):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._zoom_factor = 1.15
+
+    def wheelEvent(self, event):
+        if event.angleDelta().y() > 0:
+            self.scale(self._zoom_factor, self._zoom_factor)
+        else:
+            self.scale(1 / self._zoom_factor, 1 / self._zoom_factor)
+        event.accept()
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -162,6 +224,7 @@ class MainWindow(QMainWindow):
 
         # Mapa base
         self.chk_mapbase = QCheckBox("Usar mapa base (OSM)")
+        self.chk_mapbase.toggled.connect(self._toggle_mapbase)
         control.addWidget(self.chk_mapbase)
 
         # Proyecto / Formato
@@ -186,11 +249,16 @@ class MainWindow(QMainWindow):
         ##################
         # Lienzo (canvas)#
         ##################
-        self.canvas = QGraphicsView()
+        self.canvas = CanvasView()
         self.scene  = QGraphicsScene(self.canvas)
         self.canvas.setScene(self.scene)
         self.canvas.setMinimumSize(400,300)
         self.canvas.setStyleSheet("background-color:white; border:1px solid #ccc; padding:8px;")
+        # Permitir desplazamiento con el cursor en lugar de barras de scroll
+        self.canvas.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.canvas.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.canvas.setDragMode(QGraphicsView.ScrollHandDrag)
+        self.osm_item = None
 
         # ensamblar
         main_layout.addLayout(control,1)
@@ -390,6 +458,7 @@ class MainWindow(QMainWindow):
 
     def _show_table_menu(self, pos):
         menu = QMenu()
+        menu.addAction("Añadir fila", self._add_row)
         menu.addAction("Eliminar fila", self._delete_row)
         menu.addSeparator()
         menu.addAction("Copiar", self._copy_selection)
@@ -409,6 +478,17 @@ class MainWindow(QMainWindow):
                     parts.append(itm.text() if itm else "")
                 text += "\t".join(parts) + "\n"
         QApplication.clipboard().setText(text)
+
+    def _add_row(self):
+        r = self.table.rowCount()
+        self.table.insertRow(r)
+        id_it = QTableWidgetItem(str(r + 1))
+        id_it.setFlags(Qt.ItemIsEnabled)
+        self.table.setItem(r, 0, id_it)
+        self.table.setCurrentCell(r, 1)
+        item = QTableWidgetItem("")
+        self.table.setItem(r, 1, item)
+        self.table.editItem(item)
 
     def _delete_row(self):
         r = self.table.currentRow()
@@ -466,6 +546,39 @@ class MainWindow(QMainWindow):
             self._redraw_scene(mgr)
         except (ValueError, TypeError) as e:
              print(f"Error al construir features para preview tras pegar: {e}")
+
+    def _toggle_mapbase(self, checked):
+        if checked:
+            try:
+                mgr = self._build_manager_from_table()
+                features = mgr.get_features()
+                if not features:
+                    return
+                all_coords = [pt for feat in features for pt in feat["coords"]]
+                xs = [c[0] for c in all_coords]
+                ys = [c[1] for c in all_coords]
+                cx = sum(xs) / len(xs)
+                cy = sum(ys) / len(ys)
+                zone = int(self.cb_zona.currentText())
+                hemi = self.cb_hemisferio.currentText()
+                epsg = 32600 + zone if hemi.lower().startswith("n") else 32700 + zone
+                tr = Transformer.from_crs(f"epsg:{epsg}", "epsg:4326", always_xy=True)
+                lon, lat = tr.transform(cx, cy)
+                url = f"https://staticmap.openstreetmap.de/staticmap.php?center={lat},{lon}&zoom=16&size=512x512"
+                data = urlopen(url).read()
+                pm = QPixmap()
+                pm.loadFromData(data)
+                if self.osm_item:
+                    self.scene.removeItem(self.osm_item)
+                self.osm_item = self.scene.addPixmap(pm)
+                self.osm_item.setZValue(-1)
+                self.osm_item.setOffset(cx - pm.width()/2, cy - pm.height()/2)
+            except Exception as e:
+                QMessageBox.warning(self, "Mapa base", f"No se pudo cargar el mapa: {e}")
+        else:
+            if self.osm_item:
+                self.scene.removeItem(self.osm_item)
+                self.osm_item = None
 
 
     def _build_manager_from_table(self):
@@ -636,8 +749,15 @@ class MainWindow(QMainWindow):
 
         if file_ext in ['.csv', '.txt']:
             try:
-                # 1) Importamos todos los “features” desde el CSV
-                imported_features = CSVImporter.import_file(path)
+                # 1) Importamos todos los “features” desde el CSV.
+                #    Nuestros CSV exportados usan el orden id,x,y con cabecera.
+                imported_features = CSVImporter.import_file(
+                    path,
+                    x_col_idx=1,
+                    y_col_idx=2,
+                    id_col_idx=0,
+                    skip_header=1,
+                )
 
                 # 2) Filtramos solo aquellos que tengan:
                 #    a) Un campo "id" no vacío (feat.get("id") != "").
@@ -905,6 +1025,8 @@ class MainWindow(QMainWindow):
         try:
             mgr = self._build_manager_from_table()
             self._redraw_scene(mgr)
+            if self.scene.items():
+                self.canvas.fitInView(self.scene.itemsBoundingRect(), Qt.KeepAspectRatio)
         except (ValueError, TypeError) as e:
             QMessageBox.warning(self, "Error", f"No se pudo simular: {e}")
 

--- a/importers/kml_importer.py
+++ b/importers/kml_importer.py
@@ -280,7 +280,7 @@ if __name__ == '__main__':
     except Exception as e:
         print(f"  Error: {e}")
 
-    print(f"\n--- Probando con zona inválida ---")
+    print("\n--- Probando con zona inválida ---")
     try:
         importer.import_file(test_kml_file, target_hemisphere='Sur', target_zone=99)
     except Exception as e:


### PR DESCRIPTION
## Summary
- add CanvasView subclass with wheel zoom
- support sequential TAB editing via delegate event filter
- context menu now includes 'Añadir fila'
- base map toggle downloads a static OSM map
- center scene when simulating geometries

## Testing
- `pyflakes $(git ls-files '*.py')`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68565a70281483288511e99216a198bb