### PR TITLE
Enable Leaflet overlay integration

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -676,7 +676,10 @@ class MainWindow(QMainWindow):
             feats.append({"type": "Feature", "properties": {"id": feat["id"]}, "geometry": geom})
 
         geojson = {"type": "FeatureCollection", "features": feats}
-        js = f"window.addFeature({json.dumps(geojson)})"
+        js = (
+            "window.clearFeatures && window.clearFeatures();" 
+            f"window.addFeature({json.dumps(geojson)})"
+        )
         self.web_view.page().runJavaScript(js)
 
     def _on_guardar(self):

--- a/map_base.html
+++ b/map_base.html
@@ -11,23 +11,33 @@
 <body>
 <div id="map"></div>
 <script>
+    // Create the Leaflet map filling the entire window
     var map = L.map('map').setView([0, 0], 2);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 19,
         attribution: '&copy; OpenStreetMap contributors'
     }).addTo(map);
+    L.control.scale().addTo(map);
+
+    // Layer that will hold all features sent from Python
     var geoLayer = L.geoJSON().addTo(map);
+
+    // Add a GeoJSON feature or feature collection to the map
     window.addFeature = function(geojsonStr) {
         try {
             var data = (typeof geojsonStr === 'string') ? JSON.parse(geojsonStr) : geojsonStr;
-            geoLayer.clearLayers();
             geoLayer.addData(data);
-            if (data.features && data.features.length) {
+            if (geoLayer.getLayers().length) {
                 map.fitBounds(geoLayer.getBounds());
             }
         } catch (e) {
             console.error(e);
         }
+    };
+
+    // Remove all currently displayed features
+    window.clearFeatures = function() {
+        geoLayer.clearLayers();
     };
 </script>
 </body>


### PR DESCRIPTION
## Summary
- make Leaflet HTML handle dynamic features
- clear layers from Python before updating map

## Testing
- `python -m py_compile gui.py core/coordinate_manager.py core/geometry.py exporters/kml_exporter.py exporters/kmz_exporter.py exporters/shapefile_exporter.py importers/csv_importer.py importers/kml_importer.py config_dialog.py help_dialog.py main.py icon.py`

------
https://chatgpt.com/codex/tasks/task_e_685669db03b08328af925ff46387166a